### PR TITLE
Allow `#display_name` of Payload Objects to Fail

### DIFF
--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -60,7 +60,7 @@ module Delayed
       def name
         @name ||= payload_object.respond_to?(:display_name) ? payload_object.display_name : payload_object.class.name
       rescue StandardError => e
-        Delayed::Worker.logger&.error "Couldn't get job name: #{e.message}"
+        Delayed::Worker.logger&.error "Couldn't get job name. Falling back to parsing name from Yaml: #{e.message}"
 
         ParseObjectFromYaml.match(handler)[1]
       end

--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -59,7 +59,9 @@ module Delayed
 
       def name
         @name ||= payload_object.respond_to?(:display_name) ? payload_object.display_name : payload_object.class.name
-      rescue DeserializationError
+      rescue StandardError => e
+        Delayed::Worker.logger&.error "Couldn't get job name: #{e.message}"
+
         ParseObjectFromYaml.match(handler)[1]
       end
 

--- a/lib/delayed/backend/shared_spec.rb
+++ b/lib/delayed/backend/shared_spec.rb
@@ -279,6 +279,11 @@ shared_examples_for 'a delayed_job backend' do
       job.payload_object.object.destroy
       expect(job.reload.name).to eq('Delayed::PerformableMethod')
     end
+
+    it 'parses from handler on any error' do
+      job = described_class.new(:payload_object => MisbehavingNamedJob.new)
+      expect(job.reload.name).to eq('MisbehavingNamedJob')
+    end
   end
 
   context 'worker prioritization' do

--- a/lib/delayed/backend/shared_spec.rb
+++ b/lib/delayed/backend/shared_spec.rb
@@ -15,6 +15,7 @@ shared_examples_for 'a delayed_job backend' do
     Delayed::Worker.default_priority = 99
     Delayed::Worker.delay_jobs = true
     Delayed::Worker.default_queue_name = 'default_tracking'
+    Delayed::Worker.logger = Logger.new(StringIO.new)
     SimpleJob.runs = 0
     described_class.delete_all
   end
@@ -275,12 +276,27 @@ shared_examples_for 'a delayed_job backend' do
     end
 
     it 'parses from handler on deserialization error' do
+      allow(Delayed::Worker.logger).to receive(:error)
+
       job = Story.create(:text => '...').delay.text
       job.payload_object.object.destroy
       expect(job.reload.name).to eq('Delayed::PerformableMethod')
+
+      expect(Delayed::Worker.logger).to have_received(:error).with(/Couldn't get job name/)
     end
 
     it 'parses from handler on any error' do
+      allow(Delayed::Worker.logger).to receive(:error)
+
+      job = described_class.new(:payload_object => MisbehavingNamedJob.new)
+      expect(job.reload.name).to eq('MisbehavingNamedJob')
+
+      expect(Delayed::Worker.logger).to have_received(:error).with(/Couldn't get job name/)
+    end
+
+    it 'parses from handler on any error, when no logger is available' do
+      Delayed::Worker.logger = nil
+
       job = described_class.new(:payload_object => MisbehavingNamedJob.new)
       expect(job.reload.name).to eq('MisbehavingNamedJob')
     end

--- a/spec/sample_jobs.rb
+++ b/spec/sample_jobs.rb
@@ -109,3 +109,9 @@ class EnqueueJobMod < SimpleJob
     job.run_at = 20.minutes.from_now
   end
 end
+
+class MisbehavingNamedJob < SimpleJob
+  def display_name
+    raise "This job can't be named"
+  end
+end


### PR DESCRIPTION
Currently the `PayloadObject#display_name` method is considered in-fallible

If it does fail, the Delayed Worker will raise an exception and be restarted. Importantly it will NOT
mark the jobs as failing. This leads to a scenario where when the worker boots the same thing will happen.
A worker will pick up this 'poisoned' job since it will be the 'next up' in the queue. It will then raise an exception and restart, causing the loop to continue.

Removing the offending jobs from the queue is the only way to stop this cycle.

This PR fixes that by not assuming `display_name` is infallible. Since it is configurable by consumers, we shouldn't expect it to always succeed.

Here we take the same approach for _any_ error as was specifically happening for `DeserializationError`s. This means we will fall back to trying to read the `display_name` by parsing the serialized yml. We also add a log message for this case, so it doesn't get completely swallowed

This makes it so errors in `#display_name` don't cause the workers to crash